### PR TITLE
feat: migrate to trusted publishing

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   publish:
@@ -27,12 +28,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      - name: Configure npm authentication
-        run: |
-          echo "registry=https://registry.npmjs.org/" > $NPM_CONFIG_USERCONFIG
-          echo "@nosto:registry=https://registry.npmjs.org/" >> $NPM_CONFIG_USERCONFIG
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_TOKEN }}" >> $NPM_CONFIG_USERCONFIG
         
       - name: Check if version already exists
         id: check

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.publish == 'true'
-        run: npm publish --access public
+        run: npm publish --access public --provenance
 
       - name: Skip message
         if: steps.check.outputs.publish == 'false'

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "react-router-dom": "7.9.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.46.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
This pull request updates the `.github/workflows/npm_publish.yml` workflow configuration. The main change is the removal of the manual npm authentication step, likely in preparation for using GitHub's OIDC token for authentication. Additionally, the workflow permissions are updated to allow writing the `id-token`.

Workflow configuration updates:

* Added `id-token: write` to the workflow permissions, enabling the use of GitHub OIDC tokens for authentication.

Authentication changes:

* Removed the manual npm authentication step that set the registry and authentication token in the npm config, indicating a shift towards a more secure or automated authentication method.


## JIRA
https://nostosolutions.atlassian.net/browse/CFE-1475

## NPMJS settings
https://www.npmjs.com/package/@nosto/shopify-hydrogen/access