### PR TITLE
fix: Bump version in package.json from 2.3.1 to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "shopify",
     "hydrogen"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
This pull request contains a minor update to the package version in `package.json`.

- Bumped the package version from `2.3.1` to `2.3.2` in `package.json`.